### PR TITLE
Link Plaid API and display account balances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 .idea/
 env/
 *.css
+.env

--- a/app.py
+++ b/app.py
@@ -3,13 +3,29 @@ from flask import Flask
 from flask.views import MethodView
 from index import Index
 from sassutils.wsgi import SassMiddleware
+from dotenv import load_dotenv
 
 
 app = Flask(__name__)
 app.secret_key == os.urandom(24)
+app.wsgi_app = SassMiddleware(
+    app.wsgi_app,
+    {__name__: ("static/sass", "static/stylesheets", "static/stylesheets")},
+)
+
+# Load .env file and save data to corresponding variables
+load_dotenv()
+PLAID_CLIENT_ID = os.getenv("PLAID_CLIENT_ID")
+PLAID_SECRET = os.getenv("PLAID_SECRET")
+PLAID_PUBLIC_KEY = os.getenv("PLAID_PUBLIC_KEY")
+PLAID_ENV = os.getenv("PLAID_ENV")
+PLAID_PRODUCTS = os.getenv("PLAID_PRODUCTS")
+PLAID_COUNTRY_CODES = os.getenv("PLAID_COUNTRY_CODES")
+PLAID_OAUTH_REDIRECT_URI = os.getenv("PLAID_OAUTH_REDIRECT_URI", "")
+PLAID_OAUTH_NONCE = os.getenv("PLAID_OAUTH_NONCE", "")
+
+
 app.add_url_rule("/", view_func=Index.as_view("index"), methods=["GET"])
-app.wsgi_app = SassMiddleware(app.wsgi_app, {__name__: ('static/sass', 'static/stylesheets', 'static/stylesheets')})
 
 if __name__ == "__main__":
     app.run(debug=True)
-

--- a/app.py
+++ b/app.py
@@ -3,7 +3,6 @@ from flask import Flask
 from flask.views import MethodView
 from index import Index
 from sassutils.wsgi import SassMiddleware
-from dotenv import load_dotenv
 
 
 app = Flask(__name__)
@@ -11,26 +10,6 @@ app.secret_key == os.urandom(24)
 app.wsgi_app = SassMiddleware(
     app.wsgi_app,
     {__name__: ("static/sass", "static/stylesheets", "static/stylesheets")},
-)
-
-# Load .env file and save data to corresponding variables
-load_dotenv()
-PLAID_CLIENT_ID = os.getenv("PLAID_CLIENT_ID")
-PLAID_SECRET = os.getenv("PLAID_SECRET")
-PLAID_PUBLIC_KEY = os.getenv("PLAID_PUBLIC_KEY")
-PLAID_ENV = os.getenv("PLAID_ENV")
-PLAID_PRODUCTS = os.getenv("PLAID_PRODUCTS")
-PLAID_COUNTRY_CODES = os.getenv("PLAID_COUNTRY_CODES")
-PLAID_OAUTH_REDIRECT_URI = os.getenv("PLAID_OAUTH_REDIRECT_URI", "")
-PLAID_OAUTH_NONCE = os.getenv("PLAID_OAUTH_NONCE", "")
-
-# Initialize plaid client
-client = plaid.Client(
-    client_id=PLAID_CLIENT_ID,
-    secret=PLAID_SECRET,
-    public_key=PLAID_PUBLIC_KEY,
-    environment=PLAID_ENV,
-    api_version="2019-05-29",
 )
 
 app.add_url_rule("/", view_func=Index.as_view("index"), methods=["GET"])

--- a/app.py
+++ b/app.py
@@ -24,6 +24,14 @@ PLAID_COUNTRY_CODES = os.getenv("PLAID_COUNTRY_CODES")
 PLAID_OAUTH_REDIRECT_URI = os.getenv("PLAID_OAUTH_REDIRECT_URI", "")
 PLAID_OAUTH_NONCE = os.getenv("PLAID_OAUTH_NONCE", "")
 
+# Initialize plaid client
+client = plaid.Client(
+    client_id=PLAID_CLIENT_ID,
+    secret=PLAID_SECRET,
+    public_key=PLAID_PUBLIC_KEY,
+    environment=PLAID_ENV,
+    api_version="2019-05-29",
+)
 
 app.add_url_rule("/", view_func=Index.as_view("index"), methods=["GET"])
 

--- a/index.py
+++ b/index.py
@@ -14,7 +14,7 @@ class Index(MethodView):
 
     def get_account_data(self):
         """
-        Returns list of dictionaries containing account the following data: name, balance, type
+        Returns list of dictionaries containing the following account data: name, balance, type
         :return: list of retrieved accounts
         """
 

--- a/index.py
+++ b/index.py
@@ -14,35 +14,21 @@ class Index(MethodView):
 
     def get_account_data(self):
         """
-        Returns list of dictionaries containing account the following data: 
-            name, balance, account_id, type, account_no, routing_no
+        Returns list of dictionaries containing account the following data: name, balance, type
         :return: list of retrieved accounts
         """
 
-        # Retrive raw account data through Plaid's "Auth" endpoint
-        raw_acct_data = client.Auth.get(ACCESS_TOKEN)
+        # Retrive raw account data through Plaid's "Accounts" endpoint
+        raw_acct_data = client.Accounts.get(ACCESS_TOKEN)
 
         # Create dictionary with accounts' information
         accounts = [
             dict(
                 name=raw_acct["name"],
                 balance=raw_acct["balances"]["current"],
-                id=raw_acct["account_id"],
-                type=raw_acct["subtype"],
+                type=raw_acct["type"],
             )
             for raw_acct in raw_acct_data["accounts"]
         ]
-
-        # Retrieve account and routing numbers using ACH fields (US standard)
-        if len(raw_acct_data["numbers"]["ach"]) > 0:
-            for acct in accounts:
-                acct_no = list(
-                    filter(
-                        lambda ach_nums: ach_nums["account_id"] == acct["id"],
-                        raw_acct_data["numbers"]["ach"],
-                    )
-                )
-                acct["account_no"] = acct_no[0]["account"] if len(acct_no) > 0 else ""
-                acct["routing_no"] = acct_no[0]["routing"] if len(acct_no) > 0 else ""
 
         return accounts

--- a/index.py
+++ b/index.py
@@ -1,8 +1,48 @@
 from flask import render_template
 from flask.views import MethodView
+from settings import *
 
 
 class Index(MethodView):
     def get(self):
-        return render_template("index.html", page_name='Main')
+        """
+        GET method for index page. Calls get_account_data() to retrieve accounts.
+        :return: renders the index.html page on return
+        """
+        accounts = self.get_account_data()
+        return render_template("index.html", page_name="Main", accounts=accounts)
 
+    def get_account_data(self):
+        """
+        Returns list of dictionaries containing account the following data: 
+            name, balance, account_id, type, account_no, routing_no
+        :return: list of retrieved accounts
+        """
+
+        # Retrive raw account data through Plaid's "Auth" endpoint
+        raw_acct_data = client.Auth.get(ACCESS_TOKEN)
+
+        # Create dictionary with accounts' information
+        accounts = [
+            dict(
+                name=raw_acct["name"],
+                balance=raw_acct["balances"]["current"],
+                id=raw_acct["account_id"],
+                type=raw_acct["subtype"],
+            )
+            for raw_acct in raw_acct_data["accounts"]
+        ]
+
+        # Retrieve account and routing numbers using ACH fields (US standard)
+        if len(raw_acct_data["numbers"]["ach"]) > 0:
+            for acct in accounts:
+                acct_no = list(
+                    filter(
+                        lambda ach_nums: ach_nums["account_id"] == acct["id"],
+                        raw_acct_data["numbers"]["ach"],
+                    )
+                )
+                acct["account_no"] = acct_no[0]["account"] if len(acct_no) > 0 else ""
+                acct["routing_no"] = acct_no[0]["routing"] if len(acct_no) > 0 else ""
+
+        return accounts

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ uwsgi
 libsass
 python-dotenv
 plaid-python>=3.0.0
+black

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ gunicorn
 requests
 uwsgi
 libsass
+python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 uwsgi
 libsass
 python-dotenv
+plaid-python>=3.0.0

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,23 @@
+import os
+import plaid
+from dotenv import load_dotenv
+
+# Load .env file and save data to corresponding variables
+load_dotenv()
+PLAID_CLIENT_ID = os.getenv("PLAID_CLIENT_ID")
+PLAID_SECRET = os.getenv("PLAID_SECRET")
+PLAID_PUBLIC_KEY = os.getenv("PLAID_PUBLIC_KEY")
+PLAID_ENV = os.getenv("PLAID_ENV")
+PLAID_PRODUCTS = os.getenv("PLAID_PRODUCTS")
+PLAID_COUNTRY_CODES = os.getenv("PLAID_COUNTRY_CODES")
+ACCESS_TOKEN = os.getenv("ACCESS_TOKEN")
+API_VERSION = os.getenv("API_VERSION")
+
+# Initialize plaid client
+client = plaid.Client(
+    client_id=PLAID_CLIENT_ID,
+    secret=PLAID_SECRET,
+    public_key=PLAID_PUBLIC_KEY,
+    environment=PLAID_ENV,
+    api_version=API_VERSION,
+)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,18 +1,47 @@
 {% extends "layout.html" %}
 
 {% block head %}
-<link href="static/stylesheets/index.css" rel="stylesheet" />
+<!-- <link href="static/stylesheets/index.css" rel="stylesheet" /> -->
 {% endblock %}
 
 {% block body %}
-<nav>
-  <div class="nav-wrapper">
-    <a href="#" class="brand-logo">Dollar Tracker</a>
-    <ul id="nav-mobile" class="right hide-on-med-and-down">
-      <li><a href="#">Dashboard</a></li>
-      <li><a href="#">Settings</a></li>
-      <li><a href="#">Login/Signup</a></li>
-    </ul>
+<div class="container">
+  <div class="row">
+    <div class="col s4 m4">
+      <h5 class="center">Account Balances</h5>
+      <table class="striped">
+        <thead>
+          <tr>
+            <th><strong>Account</strong></th>
+            <th><strong>Balance</strong></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for account in accounts|selectattr("type", "equalto", "depository") %}
+          <tr>
+            <td>{{ account.name }}</td>
+            <td>${{ account.balance }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <div class="col s4 m4">
+      <h5 class="center">Savings Progress</h5>
+    </div>
+    <div class="col s4 m4">
+      <h5 class="center">Stock Performance</h5>
+    </div>
   </div>
-</nav>
-{% endblock %}
+  <div class="row">
+    <div class="col s4 m4">
+      <h5 class="center">Spending Breakdown</h5>
+    </div>
+    <div class="col s4 m4">
+      <h5 class="center">Debt Breakdown</h5>
+    </div>
+    <div class="col s4 m4">
+      <h5 class="center">Net Worth Tracker</h5>
+    </div>
+  </div>
+  {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
           </tr>
         </thead>
         <tbody>
-          {% for account in accounts|selectattr("type", "equalto", "depository") %}
+          {% for account in accounts | selectattr("type", "equalto", "depository") %}
           <tr>
             <td>{{ account.name }}</td>
             <td>${{ account.balance }}</td>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -9,8 +9,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <!--Import Google Font-->
   <link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Slab&display=swap" rel="stylesheet">
-  <link href="{{ url_for('static', filename='stylesheets/main.scss.css') }}" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="{{ url_for('static', filename='stylesheets/main.scss.css') }}" rel="stylesheet" type="text/css">
   <title>{{ page_name }} - Dollar Tracker</title>
 
   {% block head %}{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -10,7 +10,7 @@
   <!--Import Google Font-->
   <link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Slab&display=swap" rel="stylesheet">
   <link href="{{ url_for('static', filename='stylesheets/main.scss.css') }}" rel="stylesheet" type="text/css">
-<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <title>{{ page_name }} - Dollar Tracker</title>
 
   {% block head %}{% endblock %}
@@ -21,9 +21,20 @@
 </header>
 
 <body>
+  <nav role="navigation">
+    <div class="nav-wrapper">
+      <a href="#" class="brand-logo">Dollar Tracker</a>
+      <ul id="nav-mobile" class="right hide-on-med-and-down">
+        <li><a href="#">Dashboard</a></li>
+        <li><a href="#">Settings</a></li>
+        <li><a href="#">Login/Signup</a></li>
+      </ul>
+    </div>
+  </nav>
   {% block body %}{% endblock %}
   <!--JavaScript at end of body for optimized loading-->
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js">
+  </script>
   <script src="{{url_for('static', filename='javascripts/main.js')}}"></script>
 </body>
 


### PR DESCRIPTION
This PR adds the following features:
- `settings.py`: retrieves environment variables from  `.env` file and sets up Plaid API client. Plaid client can now be accessed by any file by importing `settings`
- Moved navbar to `layout.html` since it will be used by all pages
-  `get_account_data()`: retrieves account information (name, balance, type) through "Accounts" endpoint
- Created container with 6 placeholder sections to display different data points.
- Populated the "Account Balances" section with *depository* account balances only. This will allow us to use the remaining account types (credit, loan, investment) to populate information for other sections (debt calculations, investment performance, etc)